### PR TITLE
check window.Vue when get it

### DIFF
--- a/lib/vue.dart
+++ b/lib/vue.dart
@@ -19,7 +19,14 @@ dynamic getWindowProperty(String name) {
   return getProperty(_window, name);
 }
 
-dynamic _vue = getWindowProperty('Vue');
+dynamic get _vue {
+  var vue = getWindowProperty('Vue');
+  if (vue == null) {
+    throw new Exception("Can't get window.vue. Please make sure the vue.js is referenced in your html <script> tag");
+  }
+  return vue;
+}
+
 
 // @JS('console.log')
 // external dynamic _log(dynamic value);


### PR DESCRIPTION
Sometimes, the `<script src=".../vue.js"></script>` may be forgot or invalid, and the `_vue` is null. But when running, the error message may be very misleading, which is like:

```
VM127:1 Uncaught Unhandled exception:
Not a valid JS object
#0      JsNative.callConstructor (dart:js:1461)
#1      callConstructor (dart:js_util:40)
#2      VueAppBase.create (package:vue2/vue.dart:347:5)
#3      new App (http://localhost:8080/index.dart:6:31)
#4      main (http://localhost:8080/index.dart:54:13)
<asynchronous suspension>
#5      main (http://localhost:8080/index.initialize.dart:11:10)
```

Which took me more than 1 hour to find the real reason. 

So I think we'd better to check the `_vue` when  getting it, to make sure it's not null.

I changed the code, could you help to review it? I'm new to dart, not sure if there is better way to do it.