### PR TITLE
Revert the version of analyzer to 0.35 for avoiding bug

### DIFF
--- a/vue/pubspec.yaml
+++ b/vue/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://refi64.com/vuedart
 environment:
   sdk: ">=2.0.0 <3.0.0"
 dependencies:
-  analyzer: '>=0.33.0 <0.36.0'
+  analyzer: '>=0.33.0 <0.35.0'
   async: ^2.0.7
   build: ^1.0.1
   csslib: ^0.14.4


### PR DESCRIPTION
Hi, thanks for the great work. I found an issue when I tried to run VueDart, and I found out a workaround solution is to downgrade the dependent pacakge of `analyzer` to less than `0.36`, so here is the PR.

Ref: https://github.com/dart-lang/source_gen/issues/399